### PR TITLE
[FEAT/#16] 카카오 회원정보 저장

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import { AddComment } from './routes/AddCommentPage';
 import { RecommandContent } from './routes/RecommandContentPage';
 import { Route, Routes } from 'react-router-dom';
 import KakaoRedirect from './components/Login/KakaoRedirect';
+import MyPage from './routes/MyPage';
 
 export default function App() {
   return (
@@ -23,6 +24,7 @@ export default function App() {
         <Route path='add-comment' element={<AddComment />} />
         <Route path='recommand-content' element={<RecommandContent />} />
         <Route path='kakao/user' element={<KakaoRedirect />} />
+        <Route path='mypage' element={<MyPage />} />
       </Routes>
     </div>
   );

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -2,10 +2,13 @@ import React, { useState } from 'react';
 import { AiOutlineMenu } from 'react-icons/ai';
 import { BsPersonCircle } from 'react-icons/bs';
 import LoginModal from '../Login/LoginModal';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 
 export default function Header() {
   const [isOpenModal, setIsOpenModal] = useState(false);
+  const profileImage = useSelector((state) => state.user.profileImage);
+  const navigate = useNavigate();
   return (
     <div className='flex w-full h-16 shadow-md'>
       <div className='flex items-center justify-start w-[10%] ml-4'>
@@ -23,15 +26,24 @@ export default function Header() {
       <div
         className='flex items-center justify-end w-[10%] text-orange-700'
       >
-        <div
-          className='flex items-center justify-center w-4/5 gap-2 mr-4 border border-orange-500 rounded-lg cursor-pointer h-3/5' 
-          onClick={() => {
-            setIsOpenModal(true)
-          }}
-        >
-          <BsPersonCircle />
-          Login
-        </div>
+        {profileImage ? ( 
+                  <div>
+                    <img className='flex items-center justify-center w-[45px] h-[45px] gap-2 mr-4 rounded-[50%] cursor-pointer h-3/5' 
+                      src={profileImage} 
+                      onClick={()=>navigate('/mypage')}
+                      alt="프로필 이미지" />
+                  </div>
+                ) : (
+                  <div
+                    className='flex items-center justify-center w-4/5 gap-2 mr-4 border border-orange-500 rounded-lg cursor-pointer h-3/5' 
+                    onClick={() => {
+                      setIsOpenModal(true)
+                    }}
+                  >
+                    <BsPersonCircle />
+                    Login
+                  </div>
+                )}
       </div>
       {isOpenModal === true ? <LoginModal setIsOpenModal={setIsOpenModal} /> : null}
     </div>

--- a/src/components/Login/KakaoRedirect.js
+++ b/src/components/Login/KakaoRedirect.js
@@ -1,29 +1,52 @@
 import React, { useEffect } from 'react'
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
-// import { setCookie } from '../Cookies';
-import cookie from 'react-cookies'
+import { useDispatch } from 'react-redux';
+import { setUserProfile } from '../../store/KakaoLogin/kakaoUserSlice';
+
 
 const KakaoRedirect = (props) => { 
-  // const [cookies, setCookie, removeCookie] = useCookies();
-  const navigate = useNavigate();
   const params = new URL(window.location.href).searchParams;
   const code = params.get("code")
   const client_id = `${process.env.REACT_APP_KAKAO_REST_API_KEY}`;
   const redirect_uri = `${process.env.REACT_APP_KAKAO_REDIRECT_URI}`;
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
 
   useEffect(() => {
     (async () => {
       try {
         const res = await axios.post(`https://kauth.kakao.com/oauth/token?client_id=${client_id}&redirect_uri=${redirect_uri}&code=${code}&grant_type=authorization_code`);
         const token = res.data.access_token;
+        console.log("token : ",token)
+        console.log(res)
+        const status = res.status
         // window.localStorage.setItem('token', token);
+
+        const userRes = await axios.get('https://kapi.kakao.com/v2/user/me', {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        const userKakaoDataId = userRes.data.id;
+        const userKakaoData = userRes.data
+        console.log("userKakaoData : ",userKakaoData)
+        const profileImage = userRes.data.properties.profile_image;
+        const nickname = userRes.data.properties.nickname;
+        dispatch(setUserProfile({ profileImage, nickname }));
+        const userKakaoId = userKakaoDataId
+        console.log("userKakaoId : ",userKakaoId)
+
+        // 여기서 부터 우리 서비스 서버에 요청 보내기 
+        if(status === 200) {
+        // 우리 서비스의 유저라면 로그인 하기
         const body = {
           "socialType" : "KAKAO",
           "token" : `${token}`,
         }
         axios
-        .post(`http://54.180.28.153/api/v1/auth/signup`,
+        .post(`http://54.180.28.153/api/v1/auth/login`,
         body,
         {
           headers: {
@@ -32,23 +55,43 @@ const KakaoRedirect = (props) => {
         })
         .then((response)=>{
           console.log("CO_RE data : " , response);
-          // HTTP COOKIE는 서버에서 해줘야 해서 클라이언트 쪽에서는 만지는게 아닌 것 같단 소리를 들어서 
-          // 잠시만 보류 하겠습니다 ..!
+        }).catch((e)=>{
+          console.log(e.toJSON().status)
+          const status = e.toJSON().status
+          if(status === 409){
 
-          // const accessToken = response.data.data.accessToken
-          // const accessTokenCookie = {accessToken: cookie.load(`accessToken`)}
-          // console.log(accessTokenCookie)
-          // const refreshToken = response.data.data.refreshToken
-          // const refreshTokenCookie = {refreshToken: cookie.load(`refreshToken`)}
-          // console.log(refreshTokenCookie)
+          // 우리 서비스의 유저가 아니라면 회원가입 하기
+          const body = {
+            "socialType" : "KAKAO",
+            "token" : `${token}`,
+          }
+          axios
+          .post(`http://54.180.28.153/api/v1/auth/signup`,
+          body,
+          {
+            headers: {
+              "Content-type":"application/json"
+            },
+          })
+          .then((response)=>{
+            console.log("CO_RE data : " , response.data);
+          }).catch((e)=>{
+            console.log(e.toJSON())
+          })
+          navigate('/');
+          }
         })
         navigate('/');
+
+        }else{
+          alert("error")
+        }
       } catch (e) {
-        console.error(e);
+        console.log(e.toJSON())
         navigate('/');
       }
     })();
-  }, [navigate, code]);
+  }, []);
 
 
   return (

--- a/src/components/Login/KakaoRedirect.js
+++ b/src/components/Login/KakaoRedirect.js
@@ -46,7 +46,7 @@ const KakaoRedirect = (props) => {
           "token" : `${token}`,
         }
         axios
-        .post(`http://54.180.28.153/api/v1/auth/login`,
+        .post(`${process.env.REACT_APP_CORE_KAKAO_API_IP_KEY}/api/v1/auth/login`,
         body,
         {
           headers: {
@@ -66,7 +66,7 @@ const KakaoRedirect = (props) => {
             "token" : `${token}`,
           }
           axios
-          .post(`http://54.180.28.153/api/v1/auth/signup`,
+          .post(`${process.env.REACT_APP_CORE_KAKAO_API_IP_KEY}/api/v1/auth/signup`,
           body,
           {
             headers: {

--- a/src/routes/MyPage.js
+++ b/src/routes/MyPage.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { useSelector } from 'react-redux';
+
+const MyPage = () => {
+    const profileImage = useSelector((state) => state.user.profileImage);
+    const nickname = useSelector((state) => state.user.nickname);
+  return (
+  <div className='grid place-items-center'>
+    <h1>마이페이지</h1>
+    <img className='w-[500px] h-[500px] rounded-[50%]' src={profileImage} alt="프로필 이미지" />
+    <p>{nickname}님 어서오세요 !</p>
+  </div>
+  )
+}
+
+export default MyPage

--- a/src/store/KakaoLogin/kakaoUserSlice.js
+++ b/src/store/KakaoLogin/kakaoUserSlice.js
@@ -1,0 +1,22 @@
+
+import {createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  profileImage: '',
+  nickname: '',
+};
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {
+    setUserProfile: (state, action) => {
+      state.profileImage = action.payload.profileImage;
+      state.nickname = action.payload.nickname;
+    },
+  },
+});
+
+export const { setUserProfile } = userSlice.actions;
+
+export default userSlice.reducer;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,16 +1,10 @@
-import { configureStore, createSlice } from '@reduxjs/toolkit';
+import { configureStore} from '@reduxjs/toolkit';
+import userSlice from './KakaoLogin/kakaoUserSlice';
 
-const a = createSlice({
-  name: 'a',
-  initialState: 'test',
-  reducers: {
-  	test(state, action) {
-    }
-  }
-})
-
-export default configureStore({
+const store =  configureStore({
   reducer: {
-  	a: a.reducer
+    user: userSlice,
   },
 });
+
+export default store;


### PR DESCRIPTION
## 관련 이슈
## 작업 내역
- 로그인 에러 json가져오기
- 카카오 로그인 버튼 클릭 시 회원인지 에러 status로 구분
- 회원이면 로그인 api로 로그인
- 회원이 아니면 회원가입 api로 회원가입
- 카카오톡 data로 이미지, 닉네임 가져오기
- 로그인 완료 시 헤더 로그인 부분 -> 가져온 이미지 사진으로 보여주기
- 가져온 이미지, 닉네임 데이터를 마이페이지에서 보여주기
## PR 포인트
- 새로고침하면 토큰이 날아가서 자동 로그아웃이 되버려요 ㅜㅜ cookie나 localstorage에 저장 해야 되는데 그걸 아직 못해서 ,, 감안해주십쇼 ..!
## 영상
https://github.com/Team-Dasom/co-re-websites/assets/114905530/4b75e086-1a60-4379-9749-0bd41316e8c5


