### PR TITLE
[FEAT/#75] 로그아웃 서버 요청 및 새로고침 시 유지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-router-dom": "^6.16.0",
         "react-scripts": "5.0.1",
         "react-textarea-autosize": "^8.5.3",
+        "redux-persist": "^6.0.0",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -15087,6 +15088,14 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
@@ -28772,6 +28781,12 @@
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
+    },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "requires": {}
     },
     "redux-thunk": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
     "react-textarea-autosize": "^8.5.3",
+    "redux-persist": "^6.0.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -12,10 +12,9 @@ import ChatGPT from '../../images/gptImg.svg'
 export default function Header() {
 
   const [isOpenModal, setIsOpenModal] = useState(false);
-  const profileImage = useSelector((state) => state.user.profileImage);
+  const profilimg = useSelector((state) => state.user.profileImage); 
+  const accessToken = useSelector((state) => state.user.accessToken);
   const { routeTo, currentPath } = useRouter();
-  // const accessToken = useSelector((state) => state.user.accessToken); 
-  // console.log("accessToken : ",accessToken)
 
   const headerMenuClickHandler = (path) => {
     routeTo(path)
@@ -55,10 +54,10 @@ export default function Header() {
       <div
         className='flex items-center justify-end w-[10%] text-orange-700'
       >
-        {getCookie('accessToken') || getCookie('profileImage') ? ( 
+        { accessToken ? ( 
                   <div>
                     <img className='flex items-center justify-center w-[45px] h-[45px] gap-2 mr-4 rounded-[50%] cursor-pointer h-3/5' 
-                      src={getCookie('profileImage')} 
+                      src={profilimg} 
                       onClick={()=>routeTo('/mypage')}
                       alt="프로필 이미지" />
                   </div>

--- a/src/components/Login/KakaoRedirect.js
+++ b/src/components/Login/KakaoRedirect.js
@@ -17,7 +17,6 @@ const KakaoRedirect = (props) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const accessToken = useSelector((state) => state.user.accessToken); 
-  // const token = useSelector((state)=>state.)
   console.log(useSelector((state) => state.user.accessToken))
 
 
@@ -65,16 +64,13 @@ const KakaoRedirect = (props) => {
           const accessToken = response.data.data.accessToken
           dispatch(setAccessToken({accessToken}));
           const refreshToken = response.data.data.refreshToken
-          if(accessToken){
-            setCookie('accessToken',accessToken,{path:'/'})
-          }
           if(refreshToken){
             setCookie('refreshToken',refreshToken,{path:'/'})
           }
         }).catch((e)=>{
           console.log(e.toJSON().status)
           const status = e.toJSON().status
-          if(status === 409){
+          if(status === 409 || status === 404){
 
           // 우리 서비스의 유저가 아니라면 회원가입 하기
           const body = {
@@ -91,6 +87,8 @@ const KakaoRedirect = (props) => {
           })
           .then((response)=>{
             console.log("CO_RE data : " , response.data);
+            const accessToken = response.data.data.accessToken
+            dispatch(setAccessToken({accessToken}));
           }).catch((e)=>{
             console.log(e.toJSON())
           })

--- a/src/components/conversation/Conversation.js
+++ b/src/components/conversation/Conversation.js
@@ -1,10 +1,12 @@
-import { getCookie } from "components/Cookie/Cookies";
 import gptImg from '../../images/gptImg.svg'
 import defaultProfileImage from '../../images/defaultProfileImage.jpg'
+import { useSelector } from "react-redux";
 
 export default function Conversation({ data }) {
+  const accessToken = useSelector((state) => state.user.accessToken); 
+  const profileImage = useSelector((state) => state.user.profileImage); 
   const { text, isAnswer } = data;
-  const profileImageSrc = isAnswer ? gptImg : getCookie('profileImage') || defaultProfileImage;
+  const profileImageSrc = isAnswer ? gptImg : (accessToken ? profileImage : defaultProfileImage);
 
   return (
     <div className={`animate-fadeIn p-4 justify-center text-base md:gap-6 md:py-6 m-auto border-b border-solid bg-[${isAnswer ? '#EDEDED' : '#fff'}] border-[#B5B2B2]`}>

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,19 @@ import { Provider } from 'react-redux';
 import store from 'store/store';
 import { CookiesProvider } from 'react-cookie';
 
+import { PersistGate } from 'redux-persist/integration/react';
+import { persistStore } from 'redux-persist';
+
+export let persistor = persistStore(store);
+
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <CookiesProvider>
     <Provider store={store}>
-      <App />
+      <PersistGate loading={null} persistor={persistor}>
+        <App />
+      </PersistGate>
     </Provider>
   </CookiesProvider>
 );

--- a/src/pages/MyPage.js
+++ b/src/pages/MyPage.js
@@ -4,6 +4,7 @@ import { useRouter } from 'hooks/useRouter';
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux';
 import { clearAccessToken, clearUserProfile } from 'store/KakaoLogin/kakaoUserSlice';
+import persistor from '../store/store'
 
 export default function MyPage() {
   const dispatch = useDispatch()
@@ -27,6 +28,7 @@ export default function MyPage() {
       removeCookie('refreshToken', { path: '/' });
       dispatch(clearAccessToken({accessToken}));
       routeTo('/');
+      await persistor.purge()
     } catch (error) {
       console.error("로그아웃 요청 중 오류 발생: ", error);
     }

--- a/src/pages/MyPage.js
+++ b/src/pages/MyPage.js
@@ -1,25 +1,44 @@
-import { getCookie, removeCookie } from 'components/Cookie/Cookies';
+import axios from 'axios';
+import { removeCookie } from 'components/Cookie/Cookies';
 import { useRouter } from 'hooks/useRouter';
 import React from 'react'
-import Bookmark from './Bookmark';
+import { useDispatch, useSelector } from 'react-redux';
+import { clearAccessToken, clearUserProfile } from 'store/KakaoLogin/kakaoUserSlice';
 
 export default function MyPage() {
+  const dispatch = useDispatch()
+  const accessToken = useSelector((state) => state.user.accessToken); 
+  const profileImage = useSelector((state) => state.user.profileImage); 
+  const nickname = useSelector((state) => state.user.nickname); 
   const { routeTo, currentPath } = useRouter();
-  const isLogout = () => {
-    removeCookie('profileImage',{path:'/'})
-    removeCookie('nickname',{path:'/'})
-    removeCookie('accessToken',{path:'/'})
-    removeCookie('refreshToken',{path:'/'})
-    routeTo('/');
+  const isLogout = async () => {
+    try {
+      const response = await axios.post(
+        `${process.env.REACT_APP_BASE_URL}/api/v1/auth/logout`,
+        {}, // 빈 객체를 전달하여 요청 본문이 없음을 나타냅니다.
+        {
+          headers: {
+            'Authorization': `Bearer ${accessToken.accessToken}`,
+          },
+        }
+      );
+      console.log("로그아웃 data : ", response.data);
+      dispatch(clearUserProfile({profileImage, nickname}));
+      removeCookie('refreshToken', { path: '/' });
+      dispatch(clearAccessToken({accessToken}));
+      routeTo('/');
+    } catch (error) {
+      console.error("로그아웃 요청 중 오류 발생: ", error);
     }
+  };
 
   return (
   <div>
     <div className='grid place-items-center w-[636px] h-auto text-center ml-[389px] mt-[40px] mb-[40px] border-[1px] border-solid border-[#3B82F6] p-[40px] rounded-xl'>
         <h1 className='font-semibold ml-[-470px]'>기본 정보</h1>
         <div className='bg-blue-50 w-[560px] p-[30px] rounded-xl'>
-          <img className='ml-[178px] w-[150px] h-[150px] rounded-[50%]' src={getCookie('profileImage')} alt="프로필 이미지" />
-          <p className='mt-4 font-semibold'>{getCookie('nickname')}</p>
+          <img className='ml-[178px] w-[150px] h-[150px] rounded-[50%]' src={profileImage} alt="프로필 이미지" />
+          <p className='mt-4 font-semibold'>{nickname}</p>
         </div>
         <div className='mt-[10px]'>
           <div className='bg-blue-50 w-[560px] p-[30px] rounded-xl'>

--- a/src/store/KakaoLogin/kakaoUserSlice.js
+++ b/src/store/KakaoLogin/kakaoUserSlice.js
@@ -15,6 +15,9 @@ const userSlice = createSlice({
       state.profileImage = action.payload.profileImage;
       state.nickname = action.payload.nickname;
     },
+    clearUserProfile: (state) => {
+      state.accessToken = null;
+    },
     setAccessToken: (state, action) => {
       state.accessToken = action.payload;
     },
@@ -24,6 +27,6 @@ const userSlice = createSlice({
   },
 });
 
-export const { setUserProfile, setAccessToken, clearAccessToken } = userSlice.actions;
+export const { setUserProfile, setAccessToken, clearAccessToken, clearUserProfile } = userSlice.actions;
 
 export default userSlice.reducer;

--- a/src/store/KakaoLogin/kakaoUserSlice.js
+++ b/src/store/KakaoLogin/kakaoUserSlice.js
@@ -16,7 +16,8 @@ const userSlice = createSlice({
       state.nickname = action.payload.nickname;
     },
     clearUserProfile: (state) => {
-      state.accessToken = null;
+      state.profileImage = null;
+      state.nickname = null;
     },
     setAccessToken: (state, action) => {
       state.accessToken = action.payload;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -2,7 +2,7 @@ import { configureStore} from '@reduxjs/toolkit';
 import storage from 'redux-persist/lib/storage';
 import sessionStorage from 'redux-persist/es/storage/session';
 import { combineReducers } from 'redux';
-import { persistReducer} from 'redux-persist';
+import { persistReducer, persistStore} from 'redux-persist';
 import userSlice from 'store/KakaoLogin/kakaoUserSlice';
 import tokenReducer from 'store/KakaoLogin/tokenSlice';
 import statusReducer from './KakaoLogin/statusSlice';
@@ -32,5 +32,7 @@ const persistedReducer = persistReducer(persistConfig, reducers);
 const store = configureStore({
   reducer: persistedReducer,
 });
+
+export const persistor = persistStore(store);
 
 export default store;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,4 +1,7 @@
 import { configureStore} from '@reduxjs/toolkit';
+import storage from 'redux-persist/lib/storage';
+import { combineReducers } from 'redux';
+import { persistReducer } from 'redux-persist';
 import userSlice from 'store/KakaoLogin/kakaoUserSlice';
 import tokenReducer from 'store/KakaoLogin/tokenSlice';
 import statusReducer from './KakaoLogin/statusSlice';
@@ -7,16 +10,27 @@ import variebleNameSlice from 'store/variebleName/variebleNameSlice';
 import addCommentSlice from './addComment/addCommentSlice';
 import refactorCodeSlice from './refactorCode/refactorCodeSlice';
 
-const store =  configureStore({
-  reducer: {
-    user: userSlice,
-    token: tokenReducer,
-    status: statusReducer,
-    changeLanguage: changeLanguageSlice,
-    variebleName: variebleNameSlice,
-    addComment: addCommentSlice,
-    refactorCode: refactorCodeSlice
-  },
+const reducers = combineReducers({
+  user: userSlice,
+  token: tokenReducer,
+  status: statusReducer,
+  changeLanguage: changeLanguageSlice,
+  variebleName: variebleNameSlice,
+  addComment: addCommentSlice,
+  refactorCode: refactorCodeSlice
 });
+
+const persistConfig = {
+  key: 'root',
+  storage,
+  whitelist: ['user','status','token','variebleName','changeLanguage','addComment','refactorCode']
+};
+
+const persistedReducer = persistReducer(persistConfig, reducers);
+
+const store = configureStore({
+  reducer: persistedReducer,
+});
+
 
 export default store;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,7 +1,8 @@
 import { configureStore} from '@reduxjs/toolkit';
 import storage from 'redux-persist/lib/storage';
+import sessionStorage from 'redux-persist/es/storage/session';
 import { combineReducers } from 'redux';
-import { persistReducer } from 'redux-persist';
+import { persistReducer} from 'redux-persist';
 import userSlice from 'store/KakaoLogin/kakaoUserSlice';
 import tokenReducer from 'store/KakaoLogin/tokenSlice';
 import statusReducer from './KakaoLogin/statusSlice';
@@ -22,8 +23,8 @@ const reducers = combineReducers({
 
 const persistConfig = {
   key: 'root',
-  storage,
-  whitelist: ['user','status','token','variebleName','changeLanguage','addComment','refactorCode']
+  storage: storage,
+  whitelist: ['user', 'status', 'token', 'variebleName', 'changeLanguage', 'addComment', 'refactorCode']
 };
 
 const persistedReducer = persistReducer(persistConfig, reducers);
@@ -31,6 +32,5 @@ const persistedReducer = persistReducer(persistConfig, reducers);
 const store = configureStore({
   reducer: persistedReducer,
 });
-
 
 export default store;


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 로그아웃 서버 통신 구현
- redux-persist 라이브러리 install
- user, 각 기능 페이지 state를 세션에 저장

## PR 포인트

## 실행 화면

https://github.com/Team-Dasom/co-re-websites/assets/114905530/bb800167-4742-4a2d-9f54-da67a43d3249

